### PR TITLE
feat: generate types for FormRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 # Laravel Typegen
 
+## Table of contents
+- [Features](#features)
+- [Supported Versions](#supported-versions)
+- [Installation](#installation)
+- [Usage](#usage)
+    - [Enum Support](#enum-support)
+    - [Laravel Enum Support](#laravel-enum-support)
+    - [Use strongly typed `route()` function for ziggy](#use-strongly-typed-route-function-for-ziggy)
+    - [Useful types for Laravel](#useful-types-for-laravel)
+    - [Form Request types](#form-request-types)
+- [Available Options](#available-options)
+- [Development](#development)
+    - [Setup example project](#setup-example-project)
+    - [Debug](#debug)
+- [License](#license)
+
 
 ## Features
 
-- Generate TypeScript types from Laravel models
+- Generate types from Laravel's Models
 - Support Relationhips
 - Support Enum (from PHP8.1)
-- Generate route.d.ts file for ziggy
+- Generate types from Laravel's Form Requests
+- Generate types for ziggy (Routing)
 - Provide useful types for Laravel (e.g. pagination, etc.)
 
 ## Supported Versions
@@ -199,13 +216,55 @@ defineProps<{ users: Paginate<User> }>();
 </template>
 ```
 
+### Form Request types
+You can generate types from Laravel's Form Request by executing the command with the `--form-requests` option.
+
+If you have the Form Request class as shown below:
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ProfileUpdateRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['string', 'max:255'],
+            'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+        ];
+    }
+}
+```
+
+The corresponding TypeScript types will be automatically generated as follows:
+
+```ts
+// formRequests.ts
+export type ProfileUpdateRequest = {
+    name?: string;
+    email?: string;
+};
+```
+
+By using these generated types in combination with HTTP Client libraries like Axios, you can write more type-safe code.
 
 ## Available options
 
 ```bash
 Usage: laravel-typegen [options]
 
-Generate TypeScript types from your Laravel models
+Generate TypeScript types from your Laravel code
 
 Options:
   -V, --version         output the version number
@@ -215,6 +274,7 @@ Options:
   --model-path <value>  Path to model files (default: "app/Models")
   -z, --ziggy           Generate types for ziggy (default: false)
   --ignore-route-dts    Ignore generating route.d.ts (default: false)
+  --form-request        Generate types for FormRequests (default: false)
   -h, --help            display help for command
 ```
 

--- a/examples/laravel10-app/package-lock.json
+++ b/examples/laravel10-app/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "devDependencies": {
                 "@7nohe/laravel-typegen": "file:../../../laravel-typegen",
+                "@7nohe/laravel-zodgen": "^0.1.5",
                 "@inertiajs/vue3": "^1.0.2",
                 "@tailwindcss/forms": "^0.5.3",
                 "@types/ziggy-js": "^1.3.2",
@@ -35,6 +36,68 @@
             },
             "bin": {
                 "laravel-typegen": "dist/src/cli.js"
+            }
+        },
+        "node_modules/@7nohe/laravel-zodgen": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@7nohe/laravel-zodgen/-/laravel-zodgen-0.1.5.tgz",
+            "integrity": "sha512-DqayU8j0g4u7O+gHLiKaeoJNXg1cz2AVaV6mGgvpIZJfzcIQbCc2JIc39BU1GcZsJ4eyddbzbKBxLcKCO2bxhw==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^10.0.0",
+                "glob": "^9.3.2",
+                "php-parser": "^3.1.4",
+                "typescript": "^5.0.2",
+                "zod": "^3.21.4"
+            },
+            "bin": {
+                "laravel-zodgen": "dist/cli.js"
+            }
+        },
+        "node_modules/@7nohe/laravel-zodgen/node_modules/glob": {
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "minimatch": "^8.0.2",
+                "minipass": "^4.2.4",
+                "path-scurry": "^1.6.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@7nohe/laravel-zodgen/node_modules/minimatch": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@7nohe/laravel-zodgen/node_modules/typescript": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=12.20"
             }
         },
         "node_modules/@babel/parser": {
@@ -1403,6 +1466,15 @@
             "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
             "dev": true
         },
+        "node_modules/lru-cache": {
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+            "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+            "dev": true,
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.25.9",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -1483,6 +1555,15 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/muggle-string": {
@@ -1566,10 +1647,35 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
+        "node_modules/path-scurry": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
+            "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^9.0.0",
+                "minipass": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/php-parser": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.3.tgz",
-            "integrity": "sha512-hPvBmnRYPqWEtMfIFOlyjQv1q75UUtxt4U+YscKIQViGmEE2Xa4BuS1B1/cZdjy7MVcwtnr0WkEsr915LgRKOw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.4.tgz",
+            "integrity": "sha512-WUEfH4FWsVItqgOknM67msDdcUAfgPJsHhPNl6EPXzWtX+PfdY282m4i8YIJ9ALUEhf+qGDajdmW+VYqSd7Deg==",
             "dev": true
         },
         "node_modules/picocolors": {
@@ -2159,6 +2265,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.21.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+            "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/examples/laravel10-app/package.json
+++ b/examples/laravel10-app/package.json
@@ -4,7 +4,7 @@
         "dev": "vite",
         "build": "vite build",
         "type:check": "vue-tsc --noEmit",
-        "typegen": "node node_modules/@7nohe/laravel-typegen/src/cli.js -- --ziggy",
+        "typegen": "node node_modules/@7nohe/laravel-typegen/src/cli.js --ziggy --form-request",
         "typegen:laravel-enum": "node node_modules/@7nohe/laravel-typegen/src/cli.js --enum-path 'app/LaravelEnums' --laravel-enum"
     },
     "devDependencies": {

--- a/examples/laravel10-app/package.json
+++ b/examples/laravel10-app/package.json
@@ -4,11 +4,12 @@
         "dev": "vite",
         "build": "vite build",
         "type:check": "vue-tsc --noEmit",
-        "typegen": "node node_modules/@7nohe/laravel-typegen/src/cli.js --ziggy",
+        "typegen": "node node_modules/@7nohe/laravel-typegen/src/cli.js -- --ziggy",
         "typegen:laravel-enum": "node node_modules/@7nohe/laravel-typegen/src/cli.js --enum-path 'app/LaravelEnums' --laravel-enum"
     },
     "devDependencies": {
         "@7nohe/laravel-typegen": "file:../../../laravel-typegen",
+        "@7nohe/laravel-zodgen": "^0.1.5",
         "@inertiajs/vue3": "^1.0.2",
         "@tailwindcss/forms": "^0.5.3",
         "@types/ziggy-js": "^1.3.2",

--- a/examples/laravel10-app/resources/ts/types/formRequests.ts
+++ b/examples/laravel10-app/resources/ts/types/formRequests.ts
@@ -1,13 +1,6 @@
 export type ProfileUpdateRequest = {
-    name: string;
+    name?: string;
     email?: string;
-    age?: number;
-    height?: number;
-    bio: string;
-    address?: {
-        country: string;
-        city: string;
-    };
 };
 export type LoginRequest = {
     email: string;

--- a/examples/laravel10-app/resources/ts/types/formRequests.ts
+++ b/examples/laravel10-app/resources/ts/types/formRequests.ts
@@ -1,0 +1,15 @@
+export type ProfileUpdateRequest = {
+    name: string;
+    email?: string;
+    age?: number;
+    height?: number;
+    bio: string;
+    address?: {
+        country: string;
+        city: string;
+    };
+};
+export type LoginRequest = {
+    email: string;
+    password: string;
+};

--- a/examples/laravel10-app/resources/ts/types/route.d.ts
+++ b/examples/laravel10-app/resources/ts/types/route.d.ts
@@ -1,30 +1,30 @@
 import { Config, Router } from "ziggy-js";
 import { RouteParams } from "./param";
 type CustomRouter<T> = {
-    get params(): RouteParams[T];
-    current(): Extract<keyof RouteParams, T> | undefined;
-    current(
-        name: Extract<keyof RouteParams, T>,
-        params?: RouteParams[T]
-    ): boolean;
+  get params(): RouteParams[T];
+  current(): Extract<keyof RouteParams, T> | undefined;
+  current(
+    name: Extract<keyof RouteParams, T>,
+    params?: RouteParams[T]
+  ): boolean;
 } & Router;
 declare global {
-    declare function route<T extends keyof RouteParams>(): CustomRouter<T>;
-    declare function route<T extends keyof RouteParams>(
+  declare function route<T extends keyof RouteParams>(): CustomRouter<T>;
+  declare function route<T extends keyof RouteParams>(
+    name: T,
+    params?: RouteParams[T],
+    absolute?: boolean,
+    config?: Config
+  ): string;
+}
+declare module "vue" {
+  interface ComponentCustomProperties {
+    route: (<T extends keyof RouteParams>() => CustomRouter<T>) &
+      (<T extends keyof RouteParams>(
         name: T,
         params?: RouteParams[T],
         absolute?: boolean,
         config?: Config
-    ): string;
-}
-declare module "vue" {
-    interface ComponentCustomProperties {
-        route: (<T extends keyof RouteParams>() => CustomRouter<T>) &
-            (<T extends keyof RouteParams>(
-                name: T,
-                params?: RouteParams[T],
-                absolute?: boolean,
-                config?: Config
-            ) => string);
-    }
+      ) => string);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^18.11.18"
   },
   "dependencies": {
+    "@7nohe/laravel-zodgen": "^0.1.5",
     "commander": "^10.0.0",
     "glob": "^9.3.1",
     "php-parser": "^3.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 dependencies:
+  '@7nohe/laravel-zodgen':
+    specifier: ^0.1.5
+    version: 0.1.5
   commander:
     specifier: ^10.0.0
     version: 10.0.0
@@ -20,6 +23,17 @@ devDependencies:
     version: 18.11.18
 
 packages:
+
+  /@7nohe/laravel-zodgen@0.1.5:
+    resolution: {integrity: sha512-DqayU8j0g4u7O+gHLiKaeoJNXg1cz2AVaV6mGgvpIZJfzcIQbCc2JIc39BU1GcZsJ4eyddbzbKBxLcKCO2bxhw==}
+    hasBin: true
+    dependencies:
+      commander: 10.0.0
+      glob: 9.3.5
+      php-parser: 3.1.4
+      typescript: 5.0.2
+      zod: 3.21.4
+    dev: false
 
   /@types/node@18.11.18:
     resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
@@ -54,6 +68,16 @@ packages:
       path-scurry: 1.6.1
     dev: false
 
+  /glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.4
+      minipass: 4.2.5
+      path-scurry: 1.6.1
+    dev: false
+
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -62,6 +86,13 @@ packages:
   /minimatch@7.4.2:
     resolution: {integrity: sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==}
     engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
+  /minimatch@8.0.4:
+    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
     dev: false
@@ -83,8 +114,16 @@ packages:
     resolution: {integrity: sha512-hPvBmnRYPqWEtMfIFOlyjQv1q75UUtxt4U+YscKIQViGmEE2Xa4BuS1B1/cZdjy7MVcwtnr0WkEsr915LgRKOw==}
     dev: false
 
+  /php-parser@3.1.4:
+    resolution: {integrity: sha512-WUEfH4FWsVItqgOknM67msDdcUAfgPJsHhPNl6EPXzWtX+PfdY282m4i8YIJ9ALUEhf+qGDajdmW+VYqSd7Deg==}
+    dev: false
+
   /typescript@5.0.2:
     resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
     engines: {node: '>=12.20'}
     hasBin: true
+    dev: false
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,8 @@
 import { generate } from "./generate";
 import { Command } from "commander";
 import packageJson from "../package.json";
-import { defaultEnumPath, defaultModelPath, defaultOutputPath } from "./constants";
+import { defaultEnumPath, defaultModelPath, defaultOutputPath, tmpDir } from "./constants";
+import fs from "fs";
 
 export type CLIOptions = {
   output: string;
@@ -37,4 +38,8 @@ try {
   });
 } catch {
   console.log('Failed to generate types.')
+  if (fs.existsSync(tmpDir)) {
+    // Clean up
+    fs.rmSync(tmpDir, { recursive: true });
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,12 @@
 import { generate } from "./generate";
 import { Command } from "commander";
 import packageJson from "../package.json";
-import { defaultEnumPath, defaultModelPath, defaultOutputPath, tmpDir } from "./constants";
+import {
+  defaultEnumPath,
+  defaultModelPath,
+  defaultOutputPath,
+  tmpDir,
+} from "./constants";
 import fs from "fs";
 
 export type CLIOptions = {
@@ -12,6 +17,7 @@ export type CLIOptions = {
   modelPath: string;
   ziggy: boolean;
   ignoreRouteDts: boolean;
+  formRequest: boolean;
 };
 
 const program = new Command();
@@ -26,6 +32,7 @@ program
   .option("--model-path <value>", "Path to model files", defaultModelPath)
   .option("-z, --ziggy", "Generate types for ziggy", false)
   .option("--ignore-route-dts", "Ignore generating route.d.ts", false)
+  .option("--form-request", "Generate types for FormRequests", false)
   .parse();
 
 const options = program.opts<CLIOptions>();
@@ -37,7 +44,7 @@ try {
     console.log(`Types generated successfully!!`);
   });
 } catch {
-  console.log('Failed to generate types.')
+  console.log("Failed to generate types.");
   if (fs.existsSync(tmpDir)) {
     // Clean up
     fs.rmSync(tmpDir, { recursive: true });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,4 +3,6 @@ export const defaultModelPath = 'app/Models';
 export const defaultEnumPath = 'app/Enums';
 export const modelFileName = 'model.ts';
 export const routeParamsFileName = 'param.ts';
+export const formRequestsFileName = 'formRequests.ts';
 export const indexDeclarationFileName = 'route.d.ts';
+export const tmpDir = "./.laravel-typegen-tmp";

--- a/src/formRequests/createFormRequestTypes.ts
+++ b/src/formRequests/createFormRequestTypes.ts
@@ -1,0 +1,79 @@
+import { ParsedRules } from '@7nohe/laravel-zodgen';
+import ts from 'typescript'
+
+function getKeyword(name: string): ts.KeywordTypeSyntaxKind {
+  switch (name) {
+    case "string":
+      return ts.SyntaxKind.StringKeyword;
+    case "number":
+      return ts.SyntaxKind.NumberKeyword;
+    case "boolean":
+      return ts.SyntaxKind.BooleanKeyword;
+    case "undefined":
+      return ts.SyntaxKind.UndefinedKeyword;
+    default:
+      return ts.SyntaxKind.AnyKeyword;
+  }
+}
+
+export function createTypeNodeFromFields(
+  fields: { [key: string]: { name: string; isRequired: boolean } | object }
+): ts.TypeNode {
+  const isArray = "*" in fields;
+  if (isArray) {
+    const arrayValue = fields["*"];
+    const isArrayOfPrimitives = typeof arrayValue === "object" && ("name" in arrayValue) && typeof arrayValue.name === 'string';
+    if (isArrayOfPrimitives) { 
+      const arrayPrimitiveType = ts.factory.createKeywordTypeNode(getKeyword(arrayValue.name as string))
+      return ts.factory.createArrayTypeNode(arrayPrimitiveType);
+    }
+    const arrayElementType = createTypeNodeFromFields(arrayValue as any);
+    return ts.factory.createArrayTypeNode(arrayElementType);
+  }
+  const members = Object.entries(fields).flatMap<ts.PropertySignature | ts.TypeNode>(([name, value]) => {
+    const isNested = typeof value === "object" && !("name" in value);
+
+    const typeNode = isNested
+      ? createTypeNodeFromFields(value as any)
+      : ts.factory.createKeywordTypeNode(getKeyword(value.name as string));
+
+    const isRequired = isNested ? false : (value as any).isRequired;
+
+    return [ts.factory.createPropertySignature(
+      undefined,
+      name,
+      isRequired ? undefined : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+      typeNode
+    )];
+  });
+
+  return ts.factory.createTypeLiteralNode(members.filter(Boolean) as ts.TypeElement[]);
+}
+
+function createTypeAliasDeclaration(
+  typeName: string,
+  fields: { [key: string]: { name: string; isRequired: boolean } | object }
+): ts.TypeAliasDeclaration {
+  const typeNode = createTypeNodeFromFields(fields);
+
+  return ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    typeName,
+    undefined,
+    typeNode
+  );
+}
+
+export function createFormRequestTypes (rules: {
+  [k: string]: ParsedRules;
+}) {
+  const sourceFile = ts.factory.createSourceFile(
+    Object.entries(rules).map(([key, value]) => createTypeAliasDeclaration(key, value)),
+    ts.factory.createToken(ts.SyntaxKind.EndOfFileToken),
+    ts.NodeFlags.None
+  );
+
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const result = printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+  return result;
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -15,7 +15,10 @@ import {
   tmpDir,
 } from "./constants";
 import path from "path";
-import { parseFormRequests, defaultFormRequestPath } from '@7nohe/laravel-zodgen'
+import {
+  parseFormRequests,
+  defaultFormRequestPath,
+} from "@7nohe/laravel-zodgen";
 import { createFormRequestTypes } from "./formRequests/createFormRequestTypes";
 
 export async function generate(options: CLIOptions) {
@@ -79,16 +82,18 @@ export async function generate(options: CLIOptions) {
     // Copy route.d.ts
     if (!options.ignoreRouteDts) {
       fs.copyFileSync(
-        path.resolve(__dirname, '..',  'templates', indexDeclarationFileName),
+        path.resolve(__dirname, "..", "templates", indexDeclarationFileName),
         path.resolve(defaultOutputPath, indexDeclarationFileName)
       );
     }
   }
 
-  // Generate types for form requests
-  const rules = parseFormRequests(defaultFormRequestPath, true)
-  const formRequestSource = createFormRequestTypes(rules)
-  print(formRequestsFileName, formRequestSource, defaultOutputPath);
+  if (options.formRequest) {
+    // Generate types for form requests
+    const rules = parseFormRequests(defaultFormRequestPath, true);
+    const formRequestSource = createFormRequestTypes(rules);
+    print(formRequestsFileName, formRequestSource, defaultOutputPath);
+  }
 
   fs.rmSync(tmpDir, { recursive: true });
 }
@@ -96,7 +101,10 @@ export async function generate(options: CLIOptions) {
 const createModelDirectory = (modelName: string) => {
   const modelNameArray = modelName.split("/");
   modelNameArray.pop();
-  if (modelNameArray.length > 0 && !fs.existsSync(path.join(tmpDir, ...modelNameArray))) {
+  if (
+    modelNameArray.length > 0 &&
+    !fs.existsSync(path.join(tmpDir, ...modelNameArray))
+  ) {
     fs.mkdirSync(path.join(tmpDir, ...modelNameArray));
   }
 };

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -11,10 +11,13 @@ import {
   modelFileName,
   routeParamsFileName,
   indexDeclarationFileName,
+  formRequestsFileName,
+  tmpDir,
 } from "./constants";
 import path from "path";
+import { parseFormRequests, defaultFormRequestPath } from '@7nohe/laravel-zodgen'
+import { createFormRequestTypes } from "./formRequests/createFormRequestTypes";
 
-const tmpDir = "./.laravel-typegen-tmp";
 export async function generate(options: CLIOptions) {
   const parsedModelPath = path
     .join(options.modelPath, "**", "*.php")
@@ -81,6 +84,11 @@ export async function generate(options: CLIOptions) {
       );
     }
   }
+
+  // Generate types for form requests
+  const rules = parseFormRequests(defaultFormRequestPath, true)
+  const formRequestSource = createFormRequestTypes(rules)
+  print(formRequestsFileName, formRequestSource, defaultOutputPath);
 
   fs.rmSync(tmpDir, { recursive: true });
 }


### PR DESCRIPTION
## Input

```php
<?php

namespace App\Http\Requests;

use App\Models\User;
use Illuminate\Foundation\Http\FormRequest;
use Illuminate\Validation\Rule;

class ProfileUpdateRequest extends FormRequest
{
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array<string, mixed>
     */
    public function rules()
    {
        return [
            'name' => ['string', 'max:255'],
            'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
        ];
    }
}
```

## Output

```ts
export type ProfileUpdateRequest = {
    name?: string;
    email?: string;
};
```