### PR TITLE
feat: exclude vendor routes by default and add cli option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ export type CLIOptions = {
   enumPath: string;
   modelPath: string;
   ziggy: boolean;
+  vendorRoutes: boolean;
   ignoreRouteDts: boolean;
   formRequest: boolean;
 };
@@ -31,6 +32,7 @@ program
   .option("--enum-path <value>", "Path to enum files", defaultEnumPath)
   .option("--model-path <value>", "Path to model files", defaultModelPath)
   .option("-z, --ziggy", "Generate types for ziggy", false)
+  .option("--vendor-routes", "Include routes defined by vendor packages", false)
   .option("--ignore-route-dts", "Ignore generating route.d.ts", false)
   .option("--form-request", "Generate types for FormRequests", false)
   .parse();

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -65,7 +65,8 @@ export async function generate(options: CLIOptions) {
 
   // Generate types for ziggy
   if (options.ziggy) {
-    const routeListCommand = `php artisan route:list --json > ${tmpDir}/route.json`;
+    const routeListCommand = `php artisan route:list ${options.vendorRoutes ? "" : "--except-vendor"
+      } --json > ${tmpDir}/route.json`;
     execSync(routeListCommand);
     const routeJson = JSON.parse(
       fs.readFileSync(`${tmpDir}/route.json`, "utf8")


### PR DESCRIPTION
Currently working on a project with Laravel Nova, it generates a lot of routes with many route name collisions that breaks the generated param.ts

<img width="878" alt="image" src="https://github.com/7nohe/laravel-typegen/assets/933275/2344b0da-5716-4916-ad31-007284baf1bc">

`params.ts`

<img width="588" alt="image" src="https://github.com/7nohe/laravel-typegen/assets/933275/031c7bf8-1593-411c-af71-cfe5a64c7f78">

---

One solution that works for us is to modify the `php artisan route:list --json` call to include `--except-vendor`

```
--except-vendor              Do not display routes defined by vendor packages
```

Have added it here as an extra option, and seems like it might be a sane default given that the other vendored routes I've come across (examples below) don't seem like ones that would typically be utilised (e.g. DebugBar, Laravel Dusk, Laravel Ignition)

<img width="985" alt="image" src="https://github.com/7nohe/laravel-typegen/assets/933275/fcfd992f-4a75-4fd7-b586-7c827bbec5cc">