### PR TITLE
fix(glob): change import method from default to named

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -2,7 +2,7 @@ import { print } from "./print";
 import { CLIOptions } from "./cli";
 import { createSource as createModelSource } from "./models/createSource";
 import { createRouteParamsSource } from "./routes/createSource";
-import glob from "glob";
+import { sync } from "glob";
 import fs from "fs";
 import { execSync } from "child_process";
 import { LaravelModelType, LaravelRouteListType } from "./types";
@@ -25,12 +25,12 @@ export async function generate(options: CLIOptions) {
   const parsedModelPath = path
     .join(options.modelPath, "**", "*.php")
     .replace(/\\/g, "/");
-  const models = glob.sync(parsedModelPath);
+  const models = sync(parsedModelPath);
   const modelData: LaravelModelType[] = [];
   const parsedEnumPath = path
     .join(options.enumPath, "**", "*.php")
     .replace(/\\/g, "/");
-  const enums = glob.sync(parsedEnumPath);
+  const enums = sync(parsedEnumPath);
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir);
   }


### PR DESCRIPTION
Thank you for creating very useful library for laravel development with typescript.

# About

This pull request resolves #23 issue that another person submitted.
I had the same situation above issue. 

I found that cause and resolution, so I submitted this pull request.

# Summary / Cause

fix glob sync error cause of glob update that changes export method from default to named. 

Detail: 
[https://github.com/isaacs/node-glob/blob/main/changelog.md#1000](https://github.com/isaacs/node-glob/blob/main/changelog.md#1000)

# issue
#23 