### PR TITLE
Add supported columns (char, varchar, json, casted date/datetime)

### DIFF
--- a/examples/laravel10-app/package.json
+++ b/examples/laravel10-app/package.json
@@ -4,7 +4,7 @@
         "dev": "vite",
         "build": "vite build",
         "type:check": "vue-tsc --noEmit",
-        "typegen": "node node_modules/@7nohe/laravel-typegen/src/cli.js --ziggy --form-request",
+        "typegen": "node node_modules/@7nohe/laravel-typegen/dist/src/cli.js --ziggy --form-request",
         "typegen:laravel-enum": "node node_modules/@7nohe/laravel-typegen/dist/src/cli.js --enum-path 'app/LaravelEnums' --laravel-enum"
     },
     "devDependencies": {

--- a/examples/laravel10-app/resources/js/types/model.ts
+++ b/examples/laravel10-app/resources/js/types/model.ts
@@ -11,7 +11,7 @@ export type Job = {
     attempts: any;
     reserved_at?: number;
     available_at: number;
-    created_at: number;
+    created_at: string;
 };
 export type Post = {
     id: number;

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -25,12 +25,12 @@ export async function generate(options: CLIOptions) {
   const parsedModelPath = path
     .join(options.modelPath, "**", "*.php")
     .replace(/\\/g, "/");
-  const models = sync(parsedModelPath);
+  const models = sync(parsedModelPath).sort();
   const modelData: LaravelModelType[] = [];
   const parsedEnumPath = path
     .join(options.enumPath, "**", "*.php")
     .replace(/\\/g, "/");
-  const enums = sync(parsedEnumPath);
+  const enums = sync(parsedEnumPath).sort();
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir);
   }

--- a/src/models/createTypes.ts
+++ b/src/models/createTypes.ts
@@ -18,6 +18,8 @@ const keywordTypeDictionary: Record<ColumnType, TSModelKeyword> = {
   date: ts.SyntaxKind.StringKeyword,
   text: ts.SyntaxKind.StringKeyword,
   string: ts.SyntaxKind.StringKeyword,
+  char: ts.SyntaxKind.StringKeyword,
+  varchar: ts.SyntaxKind.StringKeyword,
 };
 
 const getKeywordType = (columnType: ColumnType | null) => {
@@ -27,7 +29,7 @@ const getKeywordType = (columnType: ColumnType | null) => {
   const keywordType = keywordTypeDictionary[columnType];
   if (keywordType) return keywordType;
 
-  if (columnType.match(/string|text\(/)) {
+  if (columnType.match(/string|text|char.*|varchar.*/)) {
     return ts.SyntaxKind.StringKeyword;
   }
 

--- a/src/models/createTypes.ts
+++ b/src/models/createTypes.ts
@@ -88,6 +88,22 @@ const createAttributeType = (attribute: Attribute) => {
     );
   }
 
+  // Json type
+  if (attribute.type === "json") {
+    if (attribute.cast === "array") {
+      node = ts.factory.createArrayTypeNode(
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
+      );
+    }
+
+    if (attribute.cast === "object") {
+      node = ts.factory.createTypeReferenceNode("Record", [
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+      ]);
+    }
+  }
+
   // Enum type
   if (attribute.cast && isEnum(attribute)) {
     // Create enum type node

--- a/src/models/createTypes.ts
+++ b/src/models/createTypes.ts
@@ -88,6 +88,11 @@ const createAttributeType = (attribute: Attribute) => {
     );
   }
 
+  // Date, DateTime cast
+  if (attribute.cast && ["date", "datetime"].includes(attribute.cast)) {
+    node = ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+  }
+
   // Json type
   if (attribute.type === "json") {
     if (attribute.cast === "array") {


### PR DESCRIPTION
## Updates
Added column type, casting type patterns to the existing logic
- [x] char, varchar
	- refer: https://github.com/NaoyaMiyagawa/laravel-typegen-sample/pull/1/commits/461737afd00cb67bcd5394f25d7054833c04a571
- [x] json (array, object)
	- refer: https://github.com/NaoyaMiyagawa/laravel-typegen-sample/pull/1/commits/77d2196c2b703428e07dfddb90f95e647b125003
- [x] casted date/datetime (assuming originally timestamp column)
	- refer: https://github.com/NaoyaMiyagawa/laravel-typegen-sample/pull/1/commits/f676d143717ada85fcc82cd1f9af1be140c6a580

Sort output
- [x] add sort. Somehow the exported types were aligned reversed on my local with the existing code
	- refer: https://github.com/NaoyaMiyagawa/laravel-typegen-sample/pull/1/commits/09b56f72f8d4ec624561555a5de2826005f19b37
