### PR TITLE
Support Non-Default Namespace for Model Type Export

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -40,7 +40,9 @@ export async function generate(options: CLIOptions) {
   for (const modelPath of modelPaths) {
     const modelName = modelPath
       .replace(options.modelPath.replace(/\\/g, "/") + "/", "")
-      .replace(path.extname(modelPath), ""); // remove .php extension
+      .replace(path.extname(modelPath), "") // remove .php extension
+      .split("/")
+      .at(-1)!; // get only model name without directory
 
     createModelDirectory(modelName);
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -20,12 +20,14 @@ import {
   defaultFormRequestPath,
 } from "@7nohe/laravel-zodgen";
 import { createFormRequestTypes } from "./formRequests/createFormRequestTypes";
+import { formatNamespaceForCommand, getPhpAst, getPhpNamespace } from "./utils";
 
 export async function generate(options: CLIOptions) {
   const parsedModelPath = path
     .join(options.modelPath, "**", "*.php")
     .replace(/\\/g, "/");
-  const models = sync(parsedModelPath).sort();
+  const modelPaths = sync(parsedModelPath).sort();
+
   const modelData: LaravelModelType[] = [];
   const parsedEnumPath = path
     .join(options.enumPath, "**", "*.php")
@@ -35,15 +37,19 @@ export async function generate(options: CLIOptions) {
     fs.mkdirSync(tmpDir);
   }
   // Generate models
-  for (const model of models) {
-    const modelName = model
+  for (const modelPath of modelPaths) {
+    const modelName = modelPath
       .replace(options.modelPath.replace(/\\/g, "/") + "/", "")
-      .replace(path.extname(model), ""); // remove .php extension
+      .replace(path.extname(modelPath), ""); // remove .php extension
+
     createModelDirectory(modelName);
-    const modelShowCommand = `php artisan model:show ${modelName} --json > ${path.join(
-      tmpDir,
-      `${modelName}.json`
-    )}`;
+
+    const namespacedModel =
+      getNamespaceForCommand(modelPath) + "\\\\" + modelName;
+    const outputPath = path.join(tmpDir, `${modelName}.json`);
+
+    const modelShowCommand = `php artisan model:show ${namespacedModel} --json > ${outputPath}`;
+
     try {
       execSync(modelShowCommand);
       const modelJson = JSON.parse(
@@ -65,8 +71,8 @@ export async function generate(options: CLIOptions) {
 
   // Generate types for ziggy
   if (options.ziggy) {
-    const routeListCommand = `php artisan route:list ${options.vendorRoutes ? "" : "--except-vendor"
-      } --json > ${tmpDir}/route.json`;
+    const vendorOption = options.vendorRoutes ? "" : "--except-vendor";
+    const routeListCommand = `php artisan route:list ${vendorOption} --json > ${tmpDir}/route.json`;
     execSync(routeListCommand);
     const routeJson = JSON.parse(
       fs.readFileSync(`${tmpDir}/route.json`, "utf8")
@@ -108,4 +114,25 @@ const createModelDirectory = (modelName: string) => {
   ) {
     fs.mkdirSync(path.join(tmpDir, ...modelNameArray));
   }
+};
+
+/**
+ * Cache for namespace by directory. Assume namespace is same when its directory is same
+ * e.g. { 'app/Models': 'App\Models', 'app-modules/{module}/Models': 'Modules/{Module}/Models', ... }
+ */
+const namespaceDictByDir: { [key: string]: string } = {};
+
+export const getNamespaceForCommand = (phpFilepath: string) => {
+  const dir = path.dirname(phpFilepath);
+
+  if (namespaceDictByDir[dir]) {
+    return namespaceDictByDir[dir];
+  }
+
+  const ast = getPhpAst(phpFilepath);
+  const namespace = getPhpNamespace(ast).name;
+  const namespaceForCommand = formatNamespaceForCommand(namespace);
+  namespaceDictByDir[dir] = namespaceForCommand;
+
+  return namespaceForCommand;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { defaultEnumPath } from "./constants";
 import { Attribute } from "./types";
+import { Engine, Namespace, Program } from "php-parser";
+import fs from "fs";
 
 // "app/Enums" -> "App-Enums"
 const enumPath = defaultEnumPath
@@ -13,6 +15,28 @@ export const isEnum = (attribute: Attribute, customEnumPath?: string) => {
     .match(new RegExp(customEnumPath ?? enumPath));
 };
 
-export const convertCamelToSnake = (camelCaseString: string) => {
-  return camelCaseString.replace(/[A-Z]/g, str => `_${str.toLowerCase()}`);
-}
+export const convertCamelToSnake = (camelCaseString: string): string => {
+  return camelCaseString.replace(/[A-Z]/g, (str) => `_${str.toLowerCase()}`);
+};
+
+export const formatNamespaceForCommand = (namespace: string): string => {
+  return namespace.replaceAll(/\\/g, "\\\\");
+};
+
+export const getPhpAst = (phpFilePath: string): Program => {
+  const parser = new Engine({});
+
+  const file = fs.readFileSync(phpFilePath);
+  const fileName = phpFilePath.split("/").at(-1)!;
+  const ast = parser.parseCode(file.toString(), fileName);
+
+  return ast;
+};
+
+export const getPhpNamespace = (phpAst: Program): Namespace => {
+  const namespaceObj = phpAst.children.find(
+    (child) => child.kind === "namespace"
+  ) as Namespace;
+
+  return namespaceObj;
+};


### PR DESCRIPTION
## Issues
- close: https://github.com/7nohe/laravel-typegen/issues/28

## Changes
This PR changes the way to specify a model name in `php artisan model:show` command. This change is inspired from this comment below:
- https://github.com/laravel/framework/pull/43156#discussion_r919849483

Meaning, conventionally `model:show` command was used like this:

```bash
php artisan model:show User ...
php artisan model:show Common/History ...
```

And moving forward, `model:show` command will be used like this:

```bash
php artisan model:show App\\Models\\User ...
php artisan model:show App\\Models\\Common\\History ...

// if modular monolith
php artisan model:show Modules\\Post\\Comment ...
```

## Output
Result of `debug.sh`
```
(no change)
```

Sample result of output in modular monolith structure:
- https://github.com/NaoyaMiyagawa/laravel-typegen-sample/pull/7/files