### PR TITLE
Support formRequestPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,16 +301,17 @@ Usage: laravel-typegen [options]
 Generate TypeScript types from your Laravel code
 
 Options:
-  -V, --version         output the version number
-  -o, --output <value>  Output directory (default: "resources/js/types")
-  --laravel-enum        Use Laravel Enum (default: false)
-  --enum-path <value>   Path to enum files (default: "app/Enums")
-  --model-path <value>  Path to model files (default: "app/Models")
-  -z, --ziggy           Generate types for ziggy (default: false)
-  --vendor-routes       Include routes defined by vendor packages (default: false)
-  --ignore-route-dts    Ignore generating route.d.ts (default: false)
-  --form-request        Generate types for FormRequests (default: false)
-  -h, --help            display help for command
+  -V, --version                output the version number
+  -o, --output <value>         Output directory (default: "resources/js/types")
+  --laravel-enum               Use Laravel Enum (default: false)
+  --enum-path <value>          Path to enum files (default: "app/Enums")
+  --model-path <value>         Path to model files (default: "app/Models")
+  -z, --ziggy                  Generate types for ziggy (default: false)
+  --vendor-routes              Include routes defined by vendor packages (default: false)
+  --ignore-route-dts           Ignore generating route.d.ts (default: false)
+  --form-request               Generate types for FormRequests (default: false)
+  --form-request-path <value>  Path to FormRequest files (default: "app/Http/Requests")
+  -h, --help                   display help for command
 ```
 
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
   tmpDir,
 } from "./constants";
 import fs from "fs";
+import { defaultFormRequestPath } from "@7nohe/laravel-zodgen";
 
 export type CLIOptions = {
   output: string;
@@ -19,6 +20,7 @@ export type CLIOptions = {
   vendorRoutes: boolean;
   ignoreRouteDts: boolean;
   formRequest: boolean;
+  formRequestPath: string;
 };
 
 const program = new Command();
@@ -35,6 +37,11 @@ program
   .option("--vendor-routes", "Include routes defined by vendor packages", false)
   .option("--ignore-route-dts", "Ignore generating route.d.ts", false)
   .option("--form-request", "Generate types for FormRequests", false)
+  .option(
+    "--form-request-path <value>",
+    "Path to FormRequest files",
+    defaultFormRequestPath
+  )
   .parse();
 
 const options = program.opts<CLIOptions>();

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -15,10 +15,7 @@ import {
   tmpDir,
 } from "./constants";
 import path from "path";
-import {
-  parseFormRequests,
-  defaultFormRequestPath,
-} from "@7nohe/laravel-zodgen";
+import { parseFormRequests } from "@7nohe/laravel-zodgen";
 import { createFormRequestTypes } from "./formRequests/createFormRequestTypes";
 
 export async function generate(options: CLIOptions) {
@@ -91,7 +88,7 @@ export async function generate(options: CLIOptions) {
 
   if (options.formRequest) {
     // Generate types for form requests
-    const rules = parseFormRequests(defaultFormRequestPath, true);
+    const rules = parseFormRequests(options.formRequestPath, true);
     const formRequestSource = createFormRequestTypes(rules);
     print(formRequestsFileName, formRequestSource, options.output ?? defaultOutputPath);
   }


### PR DESCRIPTION
## Issues
- close: https://github.com/7nohe/laravel-typegen/issues/30

## Changes
This PR enables users to change FormRequest file path from pre-defined default `app/Http/Requests` to a preferred path with newly added `--form-request-path` option (default: `app/Http/Requests`). This option helps projects that follow non-default folder structure such as modular monolith.

**Usage:**
```bash
pnpm laravel-typegen --model-path 'app-modules/auth/src/Models' --output 'app-modules/auth/resources/js/types' --form-request --form-request-path 'app-modules/auth/src/Http/Requests'"
```

The above is an example command in a project with following folder structure

```
app/
  - Http/
     - Requests/
app-modules/
  - auth/
    - src/
      - Http/
        - Requests/
    - resources/
      - js/
        - types/
  - ... // other modules
resources/
  - js/
    - types/
```


## Output
Result of `debug.sh`
```
(no change)
```

Sample result of output in modular monolith structure:
- https://github.com/NaoyaMiyagawa/laravel-typegen-sample/pull/8/files

## Remarks
I wasn't sure which would be better, adding a new option `--form-request-path` or accepting path value for the existing option `--form-request`. So far, I followed the way of adding a new option. I feel this is simpler and more consistent with the existing options for users.